### PR TITLE
Implement FastAPI backend for portfolio platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.venv/
+stockapp.db

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# stock-app
-stock-app
+# Stock App
+
+This repository implements the initial backend service for the multi-broker investment tracking platform alongside a detailed product requirements document. Refer to [docs/product-requirements.md](docs/product-requirements.md) for the full specification.
+
+## Getting started
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+The API is built with FastAPI and exposes CRUD endpoints for users, portfolios, accounts, assets, transactions, dividends, benchmarks, prices, and CSV imports. Once the server is running you can access the interactive API docs at `http://127.0.0.1:8000/docs`.
+
+## Running tests
+
+```bash
+pip install -r requirements.txt
+pip install pytest
+pytest
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Stock portfolio application package."""

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime
+from decimal import Decimal
+from typing import List, Optional, Sequence
+
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+
+
+# User CRUD
+
+
+def create_user(db: Session, payload: schemas.UserCreate) -> models.User:
+    user = models.User(**payload.dict())
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def list_users(db: Session) -> List[models.User]:
+    return db.query(models.User).all()
+
+
+def get_user(db: Session, user_id: int) -> Optional[models.User]:
+    return db.query(models.User).filter(models.User.id == user_id).first()
+
+
+def update_user(db: Session, user: models.User, payload: schemas.UserUpdate) -> models.User:
+    return update_entity(db, user, payload)
+
+
+def delete_user(db: Session, user: models.User) -> None:
+    db.delete(user)
+    db.commit()
+
+
+def create_entity(db: Session, model, schema):
+    instance = model(**schema.dict())
+    db.add(instance)
+    db.commit()
+    db.refresh(instance)
+    return instance
+
+
+def update_entity(db: Session, instance, schema):
+    data = schema.dict(exclude_unset=True)
+    for field, value in data.items():
+        setattr(instance, field, value)
+    db.add(instance)
+    db.commit()
+    db.refresh(instance)
+    return instance
+
+
+# Portfolio CRUD
+
+def create_portfolio(db: Session, payload: schemas.PortfolioCreate) -> models.Portfolio:
+    portfolio = models.Portfolio(**payload.dict())
+    db.add(portfolio)
+    db.commit()
+    db.refresh(portfolio)
+    return portfolio
+
+
+def list_portfolios(db: Session, user_id: Optional[int] = None) -> List[models.Portfolio]:
+    query = db.query(models.Portfolio)
+    if user_id is not None:
+        query = query.filter(models.Portfolio.user_id == user_id)
+    return query.all()
+
+
+def get_portfolio(db: Session, portfolio_id: int) -> Optional[models.Portfolio]:
+    return db.query(models.Portfolio).filter(models.Portfolio.id == portfolio_id).first()
+
+
+def update_portfolio(
+    db: Session, portfolio: models.Portfolio, payload: schemas.PortfolioUpdate
+) -> models.Portfolio:
+    return update_entity(db, portfolio, payload)
+
+
+def delete_portfolio(db: Session, portfolio: models.Portfolio) -> None:
+    db.delete(portfolio)
+    db.commit()
+
+
+# Account CRUD
+
+def create_account(db: Session, payload: schemas.AccountCreate) -> models.Account:
+    account = models.Account(**payload.dict())
+    db.add(account)
+    db.commit()
+    db.refresh(account)
+    return account
+
+
+def list_accounts(db: Session, portfolio_id: Optional[int] = None) -> List[models.Account]:
+    query = db.query(models.Account)
+    if portfolio_id is not None:
+        query = query.filter(models.Account.portfolio_id == portfolio_id)
+    return query.all()
+
+
+def get_account(db: Session, account_id: int) -> Optional[models.Account]:
+    return db.query(models.Account).filter(models.Account.id == account_id).first()
+
+
+def update_account(db: Session, account: models.Account, payload: schemas.AccountUpdate) -> models.Account:
+    return update_entity(db, account, payload)
+
+
+def delete_account(db: Session, account: models.Account) -> None:
+    db.delete(account)
+    db.commit()
+
+
+# Asset CRUD
+
+def create_asset(db: Session, payload: schemas.AssetCreate) -> models.Asset:
+    asset = models.Asset(**payload.dict())
+    db.add(asset)
+    db.commit()
+    db.refresh(asset)
+    return asset
+
+
+def list_assets(db: Session) -> List[models.Asset]:
+    return db.query(models.Asset).all()
+
+
+def get_asset(db: Session, asset_id: int) -> Optional[models.Asset]:
+    return db.query(models.Asset).filter(models.Asset.id == asset_id).first()
+
+
+def update_asset(db: Session, asset: models.Asset, payload: schemas.AssetUpdate) -> models.Asset:
+    return update_entity(db, asset, payload)
+
+
+def delete_asset(db: Session, asset: models.Asset) -> None:
+    db.delete(asset)
+    db.commit()
+
+
+# Transaction CRUD
+
+def create_transaction(
+    db: Session, payload: schemas.TransactionCreate
+) -> models.Transaction:
+    transaction = models.Transaction(**payload.dict())
+    db.add(transaction)
+    db.commit()
+    db.refresh(transaction)
+    return transaction
+
+
+def list_transactions(
+    db: Session, account_id: Optional[int] = None, portfolio_id: Optional[int] = None
+) -> List[models.Transaction]:
+    query = db.query(models.Transaction)
+    if account_id is not None:
+        query = query.filter(models.Transaction.account_id == account_id)
+    if portfolio_id is not None:
+        query = query.join(models.Account).filter(models.Account.portfolio_id == portfolio_id)
+    return query.order_by(models.Transaction.trade_time.desc()).all()
+
+
+def get_transaction(db: Session, transaction_id: int) -> Optional[models.Transaction]:
+    return (
+        db.query(models.Transaction)
+        .filter(models.Transaction.id == transaction_id)
+        .first()
+    )
+
+
+def update_transaction(
+    db: Session, transaction: models.Transaction, payload: schemas.TransactionUpdate
+) -> models.Transaction:
+    return update_entity(db, transaction, payload)
+
+
+def delete_transaction(db: Session, transaction: models.Transaction) -> None:
+    db.delete(transaction)
+    db.commit()
+
+
+# Dividend CRUD
+
+def create_dividend(db: Session, payload: schemas.DividendCreate) -> models.Dividend:
+    dividend = models.Dividend(**payload.dict())
+    db.add(dividend)
+    db.commit()
+    db.refresh(dividend)
+    return dividend
+
+
+def list_dividends(
+    db: Session, account_id: Optional[int] = None, asset_id: Optional[int] = None
+) -> List[models.Dividend]:
+    query = db.query(models.Dividend)
+    if account_id is not None:
+        query = query.filter(models.Dividend.account_id == account_id)
+    if asset_id is not None:
+        query = query.filter(models.Dividend.asset_id == asset_id)
+    return query.order_by(models.Dividend.pay_date.desc()).all()
+
+
+def get_dividend(db: Session, dividend_id: int) -> Optional[models.Dividend]:
+    return db.query(models.Dividend).filter(models.Dividend.id == dividend_id).first()
+
+
+def update_dividend(
+    db: Session, dividend: models.Dividend, payload: schemas.DividendUpdate
+) -> models.Dividend:
+    return update_entity(db, dividend, payload)
+
+
+def delete_dividend(db: Session, dividend: models.Dividend) -> None:
+    db.delete(dividend)
+    db.commit()
+
+
+# Price CRUD
+
+def upsert_price(db: Session, payload: schemas.PriceCreate) -> models.Price:
+    price = (
+        db.query(models.Price)
+        .filter(models.Price.asset_id == payload.asset_id, models.Price.date == payload.date)
+        .first()
+    )
+    if price:
+        for field, value in payload.dict().items():
+            setattr(price, field, value)
+    else:
+        price = models.Price(**payload.dict())
+        db.add(price)
+    db.commit()
+    db.refresh(price)
+    return price
+
+
+def list_prices(db: Session, asset_id: int) -> List[models.Price]:
+    return (
+        db.query(models.Price)
+        .filter(models.Price.asset_id == asset_id)
+        .order_by(models.Price.date.desc())
+        .all()
+    )
+
+
+# Benchmark CRUD
+
+def create_benchmark(db: Session, payload: schemas.BenchmarkCreate) -> models.Benchmark:
+    benchmark = models.Benchmark(**payload.dict())
+    db.add(benchmark)
+    db.commit()
+    db.refresh(benchmark)
+    return benchmark
+
+
+def list_benchmarks(db: Session) -> List[models.Benchmark]:
+    return db.query(models.Benchmark).all()
+
+
+def get_benchmark(db: Session, benchmark_id: int) -> Optional[models.Benchmark]:
+    return (
+        db.query(models.Benchmark)
+        .filter(models.Benchmark.id == benchmark_id)
+        .first()
+    )
+
+
+def update_benchmark(
+    db: Session, benchmark: models.Benchmark, payload: schemas.BenchmarkUpdate
+) -> models.Benchmark:
+    return update_entity(db, benchmark, payload)
+
+
+def delete_benchmark(db: Session, benchmark: models.Benchmark) -> None:
+    db.delete(benchmark)
+    db.commit()
+
+
+def compute_portfolio_performance(db: Session, portfolio_id: int) -> schemas.PortfolioPerformance:
+    transactions = list_transactions(db, portfolio_id=portfolio_id)
+    accounts = list_accounts(db, portfolio_id=portfolio_id)
+    account_ids = {account.id for account in accounts}
+    dividends = (
+        db.query(models.Dividend)
+        .filter(models.Dividend.account_id.in_(account_ids))
+        .all()
+        if account_ids
+        else []
+    )
+
+    invested = Decimal("0")
+    fees = Decimal("0")
+    taxes = Decimal("0")
+    realized_pl = Decimal("0")
+    position_qty: dict[int, Decimal] = defaultdict(lambda: Decimal("0"))
+    position_cost: dict[int, Decimal] = defaultdict(lambda: Decimal("0"))
+
+    for txn in transactions:
+        qty = Decimal(txn.qty)
+        price = Decimal(txn.price)
+        gross = Decimal(txn.gross_amount) if txn.gross_amount is not None else qty * price
+        sign = Decimal("1") if txn.type in {"BUY", "FEE", "TAX"} else Decimal("-1")
+        invested += gross * sign
+        fees += Decimal(txn.fee or 0)
+        taxes += Decimal(txn.tax or 0)
+
+        if txn.type == "BUY":
+            position_qty[txn.asset_id] += qty
+            position_cost[txn.asset_id] += gross + Decimal(txn.fee or 0) + Decimal(txn.tax or 0)
+        elif txn.type == "SELL":
+            held_qty = position_qty[txn.asset_id]
+            average_cost = (
+                position_cost[txn.asset_id] / held_qty if held_qty else Decimal("0")
+            )
+            position_qty[txn.asset_id] = held_qty - qty
+            realized_pl += gross - qty * average_cost
+            position_cost[txn.asset_id] -= qty * average_cost
+
+    latest_prices: dict[int, Decimal] = {}
+    price_query = (
+        db.query(models.Price)
+        .filter(models.Price.asset_id.in_(position_qty.keys()))
+        .order_by(models.Price.asset_id, models.Price.date.desc())
+    )
+    for price in price_query:
+        if price.asset_id not in latest_prices:
+            latest_prices[price.asset_id] = Decimal(price.close)
+
+    current_value = Decimal("0")
+    for asset_id, qty in position_qty.items():
+        price = latest_prices.get(asset_id)
+        if price is None:
+            continue
+        current_value += qty * price
+
+    dividends_received = sum(Decimal(div.net) for div in dividends if div.account.portfolio_id == portfolio_id)
+
+    net_cashflow = invested + dividends_received
+    unrealized_pl = current_value + dividends_received - invested
+
+    return schemas.PortfolioPerformance(
+        portfolio_id=portfolio_id,
+        total_invested=float(invested),
+        total_fees=float(fees),
+        total_taxes=float(taxes),
+        net_cashflow=float(net_cashflow),
+        current_value=float(current_value),
+        unrealized_pl=float(unrealized_pl),
+        realized_pl=float(realized_pl),
+        dividends_received=float(dividends_received),
+    )
+
+
+def preview_import(rows: Sequence[dict]) -> schemas.CSVImportPreview:
+    headers = list(rows[0].keys()) if rows else []
+    checksum = sum(float(row.get("GrossAmount", 0) or 0) for row in rows)
+    dedup_keys = set()
+    duplicates = 0
+    for row in rows:
+        key = (
+            row.get("Account"),
+            row.get("Date"),
+            row.get("Ticker/ISIN"),
+            row.get("Qty"),
+            row.get("Price"),
+        )
+        if key in dedup_keys:
+            duplicates += 1
+        else:
+            dedup_keys.add(key)
+    return schemas.CSVImportPreview(headers=headers, rows=list(rows[:100]), checksum=checksum, duplicates=duplicates)
+
+
+def ingest_transactions(db: Session, rows: Sequence[dict], account_lookup: dict[str, int]) -> schemas.ImportResult:
+    imported = 0
+    skipped = 0
+    checksum = Decimal("0")
+
+    for row in rows:
+        account_name = row.get("Account")
+        account_id = account_lookup.get(account_name)
+        if not account_id:
+            skipped += 1
+            continue
+        asset_symbol = row.get("Ticker/ISIN") or row.get("Ticker")
+        asset = (
+            db.query(models.Asset).filter(models.Asset.symbol == asset_symbol).first()
+        )
+        if not asset:
+            asset = models.Asset(
+                symbol=asset_symbol,
+                name=row.get("Name") or asset_symbol,
+                type="stock",
+                currency=row.get("Currency") or "USD",
+            )
+            db.add(asset)
+            db.flush()
+        transaction = models.Transaction(
+            account_id=account_id,
+            asset_id=asset.id,
+            type=row.get("Type", "BUY"),
+            qty=Decimal(row.get("Qty") or 0),
+            price=Decimal(row.get("Price") or 0),
+            fee=Decimal(row.get("Fee") or 0),
+            tax=Decimal(row.get("Tax") or 0),
+            gross_amount=Decimal(row.get("GrossAmount") or 0),
+            trade_currency=row.get("Currency") or "USD",
+            trade_time=datetime.fromisoformat(row.get("Date")),
+        )
+        db.add(transaction)
+        checksum += Decimal(row.get("Qty") or 0) * Decimal(row.get("Price") or 0)
+        imported += 1
+    db.commit()
+
+    checksum_diff = float(checksum - sum(Decimal(row.get("GrossAmount") or 0) for row in rows))
+
+    return schemas.ImportResult(
+        imported_transactions=imported,
+        skipped_rows=skipped,
+        checksum_diff=checksum_diff,
+    )

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./stockapp.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+@contextmanager
+def session_scope() -> Generator:
+    """Provide a transactional scope around a series of operations."""
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def get_db() -> Generator:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .database import Base, engine
+from .routers import (
+    accounts,
+    assets,
+    benchmarks,
+    dividends,
+    imports,
+    portfolios,
+    transactions,
+    users,
+    prices,
+)
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Stock Portfolio Platform", version="0.1.0")
+
+app.include_router(portfolios.router)
+app.include_router(accounts.router)
+app.include_router(assets.router)
+app.include_router(transactions.router)
+app.include_router(dividends.router)
+app.include_router(benchmarks.router)
+app.include_router(imports.router)
+app.include_router(users.router)
+app.include_router(prices.router)
+
+
+@app.get("/health")
+def healthcheck():
+    return {"status": "ok"}

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+
+class TimestampMixin:
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+
+class User(Base, TimestampMixin):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, nullable=False, index=True)
+    auth_provider = Column(String, nullable=False, default="password")
+    two_factor_enabled = Column(Boolean, default=False)
+
+    portfolios = relationship("Portfolio", back_populates="owner", cascade="all,delete")
+
+
+class Benchmark(Base, TimestampMixin):
+    __tablename__ = "benchmarks"
+
+    id = Column(Integer, primary_key=True, index=True)
+    symbol = Column(String, nullable=True)
+    custom_series_ref = Column(String, nullable=True)
+    name = Column(String, nullable=False)
+    currency = Column(String(3), nullable=False)
+
+    portfolios = relationship("Portfolio", back_populates="benchmark")
+
+
+class Portfolio(Base, TimestampMixin):
+    __tablename__ = "portfolios"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    name = Column(String, nullable=False)
+    base_currency = Column(String(3), nullable=False, default="USD")
+    benchmark_id = Column(Integer, ForeignKey("benchmarks.id"), nullable=True)
+
+    owner = relationship("User", back_populates="portfolios")
+    benchmark = relationship("Benchmark", back_populates="portfolios")
+    accounts = relationship("Account", back_populates="portfolio", cascade="all,delete")
+    report_caches = relationship(
+        "ReportCache", back_populates="portfolio", cascade="all,delete-orphan"
+    )
+
+
+class Account(Base, TimestampMixin):
+    __tablename__ = "accounts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    portfolio_id = Column(Integer, ForeignKey("portfolios.id"), nullable=False)
+    broker = Column(String, nullable=False)
+    account_name = Column(String, nullable=False)
+    type = Column(String, nullable=False, default="broker")
+    currency = Column(String(3), nullable=False)
+
+    portfolio = relationship("Portfolio", back_populates="accounts")
+    transactions = relationship(
+        "Transaction", back_populates="account", cascade="all,delete-orphan"
+    )
+    dividends = relationship(
+        "Dividend", back_populates="account", cascade="all,delete-orphan"
+    )
+
+
+class Asset(Base, TimestampMixin):
+    __tablename__ = "assets"
+
+    id = Column(Integer, primary_key=True, index=True)
+    symbol = Column(String, nullable=False, index=True)
+    isin = Column(String, nullable=True, index=True)
+    name = Column(String, nullable=False)
+    type = Column(String, nullable=False)
+    sector = Column(String, nullable=True)
+    region = Column(String, nullable=True)
+    currency = Column(String(3), nullable=False)
+
+    transactions = relationship(
+        "Transaction", back_populates="asset", cascade="all,delete-orphan"
+    )
+    dividends = relationship("Dividend", back_populates="asset", cascade="all,delete")
+    prices = relationship("Price", back_populates="asset", cascade="all,delete")
+
+
+class Transaction(Base, TimestampMixin):
+    __tablename__ = "transactions"
+    __table_args__ = (
+        UniqueConstraint(
+            "account_id",
+            "trade_time",
+            "asset_id",
+            "qty",
+            "price",
+            name="uq_transaction_dedup",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    account_id = Column(Integer, ForeignKey("accounts.id"), nullable=False)
+    asset_id = Column(Integer, ForeignKey("assets.id"), nullable=False)
+    type = Column(String, nullable=False)
+    qty = Column(Numeric(18, 4), nullable=False)
+    price = Column(Numeric(18, 4), nullable=False)
+    fee = Column(Numeric(18, 4), nullable=True, default=0)
+    tax = Column(Numeric(18, 4), nullable=True, default=0)
+    gross_amount = Column(Numeric(18, 4), nullable=True)
+    trade_currency = Column(String(3), nullable=False)
+    fx_rate_to_portfolio_ccy = Column(Float, nullable=True)
+    trade_time = Column(DateTime, default=datetime.utcnow, index=True)
+
+    account = relationship("Account", back_populates="transactions")
+    asset = relationship("Asset", back_populates="transactions")
+
+
+class Dividend(Base, TimestampMixin):
+    __tablename__ = "dividends"
+
+    id = Column(Integer, primary_key=True, index=True)
+    account_id = Column(Integer, ForeignKey("accounts.id"), nullable=False)
+    asset_id = Column(Integer, ForeignKey("assets.id"), nullable=False)
+    ex_date = Column(Date, nullable=False)
+    pay_date = Column(Date, nullable=False)
+    gross = Column(Numeric(18, 4), nullable=False)
+    withholding_tax = Column(Numeric(18, 4), nullable=True, default=0)
+    net = Column(Numeric(18, 4), nullable=False)
+    currency = Column(String(3), nullable=False)
+
+    account = relationship("Account", back_populates="dividends")
+    asset = relationship("Asset", back_populates="dividends")
+
+
+class Price(Base, TimestampMixin):
+    __tablename__ = "prices"
+    __table_args__ = (
+        UniqueConstraint("asset_id", "date", name="uq_price_asset_date"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    asset_id = Column(Integer, ForeignKey("assets.id"), nullable=False)
+    date = Column(Date, nullable=False, index=True)
+    close = Column(Numeric(18, 4), nullable=False)
+    currency = Column(String(3), nullable=False)
+    source = Column(String, nullable=True)
+
+    asset = relationship("Asset", back_populates="prices")
+
+
+class ReportCache(Base, TimestampMixin):
+    __tablename__ = "report_cache"
+    __table_args__ = (
+        UniqueConstraint("portfolio_id", "key", name="uq_report_cache_portfolio_key"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    portfolio_id = Column(Integer, ForeignKey("portfolios.id"), nullable=False)
+    key = Column(String, nullable=False)
+    payload_json = Column(String, nullable=False)
+    computed_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    portfolio = relationship("Portfolio", back_populates="report_caches")
+
+
+class AuditLog(Base, TimestampMixin):
+    __tablename__ = "audit_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    entity = Column(String, nullable=False)
+    entity_id = Column(Integer, nullable=False)
+    action = Column(String, nullable=False)
+    before = Column(String, nullable=True)
+    after = Column(String, nullable=True)
+    ts = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    user = relationship("User")

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,0 +1,11 @@
+__all__ = [
+    "portfolios",
+    "accounts",
+    "assets",
+    "transactions",
+    "dividends",
+    "benchmarks",
+    "imports",
+    "users",
+    "prices",
+]

--- a/app/routers/accounts.py
+++ b/app/routers/accounts.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import crud, schemas
+from ..database import get_db
+
+router = APIRouter(prefix="/accounts", tags=["accounts"])
+
+
+@router.post("/", response_model=schemas.Account, status_code=status.HTTP_201_CREATED)
+def create_account(payload: schemas.AccountCreate, db: Session = Depends(get_db)):
+    return crud.create_account(db, payload)
+
+
+@router.get("/", response_model=list[schemas.Account])
+def list_accounts(portfolio_id: int | None = None, db: Session = Depends(get_db)):
+    return crud.list_accounts(db, portfolio_id=portfolio_id)
+
+
+@router.get("/{account_id}", response_model=schemas.Account)
+def get_account(account_id: int, db: Session = Depends(get_db)):
+    account = crud.get_account(db, account_id)
+    if not account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    return account
+
+
+@router.put("/{account_id}", response_model=schemas.Account)
+def update_account(account_id: int, payload: schemas.AccountUpdate, db: Session = Depends(get_db)):
+    account = crud.get_account(db, account_id)
+    if not account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    return crud.update_account(db, account, payload)
+
+
+@router.delete("/{account_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_account(account_id: int, db: Session = Depends(get_db)):
+    account = crud.get_account(db, account_id)
+    if not account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Account not found")
+    crud.delete_account(db, account)

--- a/app/routers/assets.py
+++ b/app/routers/assets.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import crud, schemas
+from ..database import get_db
+
+router = APIRouter(prefix="/assets", tags=["assets"])
+
+
+@router.post("/", response_model=schemas.Asset, status_code=status.HTTP_201_CREATED)
+def create_asset(payload: schemas.AssetCreate, db: Session = Depends(get_db)):
+    return crud.create_asset(db, payload)
+
+
+@router.get("/", response_model=list[schemas.Asset])
+def list_assets(db: Session = Depends(get_db)):
+    return crud.list_assets(db)
+
+
+@router.get("/{asset_id}", response_model=schemas.Asset)
+def get_asset(asset_id: int, db: Session = Depends(get_db)):
+    asset = crud.get_asset(db, asset_id)
+    if not asset:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Asset not found")
+    return asset
+
+
+@router.put("/{asset_id}", response_model=schemas.Asset)
+def update_asset(asset_id: int, payload: schemas.AssetUpdate, db: Session = Depends(get_db)):
+    asset = crud.get_asset(db, asset_id)
+    if not asset:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Asset not found")
+    return crud.update_asset(db, asset, payload)
+
+
+@router.delete("/{asset_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_asset(asset_id: int, db: Session = Depends(get_db)):
+    asset = crud.get_asset(db, asset_id)
+    if not asset:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Asset not found")
+    crud.delete_asset(db, asset)

--- a/app/routers/benchmarks.py
+++ b/app/routers/benchmarks.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import crud, schemas
+from ..database import get_db
+
+router = APIRouter(prefix="/benchmarks", tags=["benchmarks"])
+
+
+@router.post("/", response_model=schemas.Benchmark, status_code=status.HTTP_201_CREATED)
+def create_benchmark(payload: schemas.BenchmarkCreate, db: Session = Depends(get_db)):
+    return crud.create_benchmark(db, payload)
+
+
+@router.get("/", response_model=list[schemas.Benchmark])
+def list_benchmarks(db: Session = Depends(get_db)):
+    return crud.list_benchmarks(db)
+
+
+@router.get("/{benchmark_id}", response_model=schemas.Benchmark)
+def get_benchmark(benchmark_id: int, db: Session = Depends(get_db)):
+    benchmark = crud.get_benchmark(db, benchmark_id)
+    if not benchmark:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Benchmark not found")
+    return benchmark
+
+
+@router.put("/{benchmark_id}", response_model=schemas.Benchmark)
+def update_benchmark(benchmark_id: int, payload: schemas.BenchmarkUpdate, db: Session = Depends(get_db)):
+    benchmark = crud.get_benchmark(db, benchmark_id)
+    if not benchmark:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Benchmark not found")
+    return crud.update_benchmark(db, benchmark, payload)
+
+
+@router.delete("/{benchmark_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_benchmark(benchmark_id: int, db: Session = Depends(get_db)):
+    benchmark = crud.get_benchmark(db, benchmark_id)
+    if not benchmark:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Benchmark not found")
+    crud.delete_benchmark(db, benchmark)

--- a/app/routers/dividends.py
+++ b/app/routers/dividends.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import crud, schemas
+from ..database import get_db
+
+router = APIRouter(prefix="/dividends", tags=["dividends"])
+
+
+@router.post("/", response_model=schemas.Dividend, status_code=status.HTTP_201_CREATED)
+def create_dividend(payload: schemas.DividendCreate, db: Session = Depends(get_db)):
+    return crud.create_dividend(db, payload)
+
+
+@router.get("/", response_model=list[schemas.Dividend])
+def list_dividends(
+    account_id: int | None = None,
+    asset_id: int | None = None,
+    upcoming_only: bool = False,
+    db: Session = Depends(get_db),
+):
+    dividends = crud.list_dividends(db, account_id=account_id, asset_id=asset_id)
+    if upcoming_only:
+        today = date.today()
+        dividends = [div for div in dividends if div.pay_date >= today]
+    return dividends
+
+
+@router.get("/{dividend_id}", response_model=schemas.Dividend)
+def get_dividend(dividend_id: int, db: Session = Depends(get_db)):
+    dividend = crud.get_dividend(db, dividend_id)
+    if not dividend:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dividend not found")
+    return dividend
+
+
+@router.put("/{dividend_id}", response_model=schemas.Dividend)
+def update_dividend(dividend_id: int, payload: schemas.DividendUpdate, db: Session = Depends(get_db)):
+    dividend = crud.get_dividend(db, dividend_id)
+    if not dividend:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dividend not found")
+    return crud.update_dividend(db, dividend, payload)
+
+
+@router.delete("/{dividend_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_dividend(dividend_id: int, db: Session = Depends(get_db)):
+    dividend = crud.get_dividend(db, dividend_id)
+    if not dividend:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Dividend not found")
+    crud.delete_dividend(db, dividend)

--- a/app/routers/imports.py
+++ b/app/routers/imports.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import csv
+from io import StringIO
+from typing import List
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from sqlalchemy.orm import Session
+
+from .. import crud, schemas
+from ..database import get_db
+
+router = APIRouter(prefix="/imports", tags=["imports"])
+
+
+def _parse_csv(file: UploadFile) -> List[dict]:
+    content = file.file.read().decode("utf-8")
+    reader = csv.DictReader(StringIO(content))
+    return list(reader)
+
+
+@router.post("/preview", response_model=schemas.CSVImportPreview)
+def preview(file: UploadFile = File(...)):
+    if not file.filename.endswith(".csv"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Only CSV files are supported")
+    rows = _parse_csv(file)
+    return crud.preview_import(rows)
+
+
+@router.post("/ingest", response_model=schemas.ImportResult)
+def ingest(
+    portfolio_id: int,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+):
+    if not file.filename.endswith(".csv"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Only CSV files are supported")
+    rows = _parse_csv(file)
+    accounts = crud.list_accounts(db, portfolio_id=portfolio_id)
+    account_lookup = {account.account_name: account.id for account in accounts}
+    return crud.ingest_transactions(db, rows, account_lookup)

--- a/app/routers/portfolios.py
+++ b/app/routers/portfolios.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import crud, schemas
+from ..database import get_db
+
+router = APIRouter(prefix="/portfolios", tags=["portfolios"])
+
+
+@router.post("/", response_model=schemas.Portfolio, status_code=status.HTTP_201_CREATED)
+def create_portfolio(payload: schemas.PortfolioCreate, db: Session = Depends(get_db)):
+    return crud.create_portfolio(db, payload)
+
+
+@router.get("/", response_model=list[schemas.Portfolio])
+def list_portfolios(user_id: int | None = None, db: Session = Depends(get_db)):
+    return crud.list_portfolios(db, user_id=user_id)
+
+
+@router.get("/{portfolio_id}", response_model=schemas.Portfolio)
+def get_portfolio(portfolio_id: int, db: Session = Depends(get_db)):
+    portfolio = crud.get_portfolio(db, portfolio_id)
+    if not portfolio:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Portfolio not found")
+    return portfolio
+
+
+@router.put("/{portfolio_id}", response_model=schemas.Portfolio)
+def update_portfolio(portfolio_id: int, payload: schemas.PortfolioUpdate, db: Session = Depends(get_db)):
+    portfolio = crud.get_portfolio(db, portfolio_id)
+    if not portfolio:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Portfolio not found")
+    return crud.update_portfolio(db, portfolio, payload)
+
+
+@router.delete("/{portfolio_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_portfolio(portfolio_id: int, db: Session = Depends(get_db)):
+    portfolio = crud.get_portfolio(db, portfolio_id)
+    if not portfolio:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Portfolio not found")
+    crud.delete_portfolio(db, portfolio)
+
+
+@router.get("/{portfolio_id}/performance", response_model=schemas.PortfolioPerformance)
+def portfolio_performance(portfolio_id: int, db: Session = Depends(get_db)):
+    portfolio = crud.get_portfolio(db, portfolio_id)
+    if not portfolio:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Portfolio not found")
+    return crud.compute_portfolio_performance(db, portfolio_id)

--- a/app/routers/prices.py
+++ b/app/routers/prices.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from .. import crud, schemas
+from ..database import get_db
+
+router = APIRouter(prefix="/prices", tags=["prices"])
+
+
+@router.post("/", response_model=schemas.Price, status_code=status.HTTP_201_CREATED)
+def upsert_price(payload: schemas.PriceCreate, db: Session = Depends(get_db)):
+    return crud.upsert_price(db, payload)
+
+
+@router.get("/{asset_id}", response_model=list[schemas.Price])
+def list_prices(asset_id: int, db: Session = Depends(get_db)):
+    return crud.list_prices(db, asset_id)

--- a/app/routers/transactions.py
+++ b/app/routers/transactions.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import crud, schemas
+from ..database import get_db
+
+router = APIRouter(prefix="/transactions", tags=["transactions"])
+
+
+@router.post("/", response_model=schemas.Transaction, status_code=status.HTTP_201_CREATED)
+def create_transaction(payload: schemas.TransactionCreate, db: Session = Depends(get_db)):
+    return crud.create_transaction(db, payload)
+
+
+@router.get("/", response_model=list[schemas.Transaction])
+def list_transactions(
+    account_id: int | None = None,
+    portfolio_id: int | None = None,
+    db: Session = Depends(get_db),
+):
+    return crud.list_transactions(db, account_id=account_id, portfolio_id=portfolio_id)
+
+
+@router.get("/{transaction_id}", response_model=schemas.Transaction)
+def get_transaction(transaction_id: int, db: Session = Depends(get_db)):
+    transaction = crud.get_transaction(db, transaction_id)
+    if not transaction:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
+    return transaction
+
+
+@router.put("/{transaction_id}", response_model=schemas.Transaction)
+def update_transaction(transaction_id: int, payload: schemas.TransactionUpdate, db: Session = Depends(get_db)):
+    transaction = crud.get_transaction(db, transaction_id)
+    if not transaction:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
+    return crud.update_transaction(db, transaction, payload)
+
+
+@router.delete("/{transaction_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_transaction(transaction_id: int, db: Session = Depends(get_db)):
+    transaction = crud.get_transaction(db, transaction_id)
+    if not transaction:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
+    crud.delete_transaction(db, transaction)

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import crud, schemas
+from ..database import get_db
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.post("/", response_model=schemas.User, status_code=status.HTTP_201_CREATED)
+def create_user(payload: schemas.UserCreate, db: Session = Depends(get_db)):
+    return crud.create_user(db, payload)
+
+
+@router.get("/", response_model=list[schemas.User])
+def list_users(db: Session = Depends(get_db)):
+    return crud.list_users(db)
+
+
+@router.get("/{user_id}", response_model=schemas.User)
+def get_user(user_id: int, db: Session = Depends(get_db)):
+    user = crud.get_user(db, user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return user
+
+
+@router.put("/{user_id}", response_model=schemas.User)
+def update_user(user_id: int, payload: schemas.UserUpdate, db: Session = Depends(get_db)):
+    user = crud.get_user(db, user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return crud.update_user(db, user, payload)
+
+
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_user(user_id: int, db: Session = Depends(get_db)):
+    user = crud.get_user(db, user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    crud.delete_user(db, user)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, condecimal
+
+
+Decimal = condecimal(max_digits=18, decimal_places=4)
+
+
+class PortfolioBase(BaseModel):
+    name: str
+    base_currency: str = Field(..., min_length=3, max_length=3)
+    benchmark_id: Optional[int] = None
+
+
+class PortfolioCreate(PortfolioBase):
+    user_id: int
+
+
+class PortfolioUpdate(BaseModel):
+    name: Optional[str]
+    base_currency: Optional[str]
+    benchmark_id: Optional[int]
+
+
+class Portfolio(PortfolioBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class AccountBase(BaseModel):
+    portfolio_id: int
+    broker: str
+    account_name: str
+    type: str = Field(..., regex="^(broker|cash)$")
+    currency: str = Field(..., min_length=3, max_length=3)
+
+
+class AccountCreate(AccountBase):
+    pass
+
+
+class AccountUpdate(BaseModel):
+    broker: Optional[str]
+    account_name: Optional[str]
+    type: Optional[str]
+    currency: Optional[str]
+
+
+class Account(AccountBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class AssetBase(BaseModel):
+    symbol: str
+    isin: Optional[str]
+    name: str
+    type: str
+    sector: Optional[str]
+    region: Optional[str]
+    currency: str = Field(..., min_length=3, max_length=3)
+
+
+class AssetCreate(AssetBase):
+    pass
+
+
+class AssetUpdate(BaseModel):
+    symbol: Optional[str]
+    isin: Optional[str]
+    name: Optional[str]
+    type: Optional[str]
+    sector: Optional[str]
+    region: Optional[str]
+    currency: Optional[str]
+
+
+class Asset(AssetBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class TransactionType(str, Enum):
+    BUY = "BUY"
+    SELL = "SELL"
+    DIVIDEND = "DIVIDEND"
+    FEE = "FEE"
+    TAX = "TAX"
+    SPLIT = "SPLIT"
+    FX = "FX"
+
+
+class TransactionBase(BaseModel):
+    account_id: int
+    asset_id: int
+    type: TransactionType
+    qty: Decimal
+    price: Decimal
+    fee: Optional[Decimal] = 0
+    tax: Optional[Decimal] = 0
+    gross_amount: Optional[Decimal]
+    trade_currency: str = Field(..., min_length=3, max_length=3)
+    fx_rate_to_portfolio_ccy: Optional[float]
+    trade_time: datetime
+
+
+class TransactionCreate(TransactionBase):
+    pass
+
+
+class TransactionUpdate(BaseModel):
+    type: Optional[TransactionType]
+    qty: Optional[Decimal]
+    price: Optional[Decimal]
+    fee: Optional[Decimal]
+    tax: Optional[Decimal]
+    gross_amount: Optional[Decimal]
+    trade_currency: Optional[str]
+    fx_rate_to_portfolio_ccy: Optional[float]
+    trade_time: Optional[datetime]
+
+
+class Transaction(TransactionBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class DividendBase(BaseModel):
+    account_id: int
+    asset_id: int
+    ex_date: date
+    pay_date: date
+    gross: Decimal
+    withholding_tax: Optional[Decimal] = 0
+    net: Decimal
+    currency: str = Field(..., min_length=3, max_length=3)
+
+
+class DividendCreate(DividendBase):
+    pass
+
+
+class DividendUpdate(BaseModel):
+    ex_date: Optional[date]
+    pay_date: Optional[date]
+    gross: Optional[Decimal]
+    withholding_tax: Optional[Decimal]
+    net: Optional[Decimal]
+    currency: Optional[str]
+
+
+class Dividend(DividendBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class PriceBase(BaseModel):
+    asset_id: int
+    date: date
+    close: Decimal
+    currency: str = Field(..., min_length=3, max_length=3)
+    source: Optional[str]
+
+
+class PriceCreate(PriceBase):
+    pass
+
+
+class PriceUpdate(BaseModel):
+    close: Optional[Decimal]
+    currency: Optional[str]
+    source: Optional[str]
+
+
+class Price(PriceBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class BenchmarkBase(BaseModel):
+    symbol: Optional[str]
+    custom_series_ref: Optional[str]
+    name: str
+    currency: str = Field(..., min_length=3, max_length=3)
+
+
+class BenchmarkCreate(BenchmarkBase):
+    pass
+
+
+class BenchmarkUpdate(BaseModel):
+    symbol: Optional[str]
+    custom_series_ref: Optional[str]
+    name: Optional[str]
+    currency: Optional[str]
+
+
+class Benchmark(BenchmarkBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class UserBase(BaseModel):
+    email: str
+    auth_provider: str = "password"
+    two_factor_enabled: bool = False
+
+
+class UserCreate(UserBase):
+    pass
+
+
+class UserUpdate(BaseModel):
+    email: Optional[str]
+    auth_provider: Optional[str]
+    two_factor_enabled: Optional[bool]
+
+
+class User(UserBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class PortfolioPerformance(BaseModel):
+    portfolio_id: int
+    total_invested: float
+    total_fees: float
+    total_taxes: float
+    net_cashflow: float
+    current_value: float
+    unrealized_pl: float
+    realized_pl: float
+    dividends_received: float
+
+
+class CSVImportPreview(BaseModel):
+    headers: List[str]
+    rows: List[dict]
+    checksum: float
+    duplicates: int
+
+
+class ImportResult(BaseModel):
+    imported_transactions: int
+    skipped_rows: int
+    checksum_diff: float

--- a/docs/product-requirements.md
+++ b/docs/product-requirements.md
@@ -1,0 +1,110 @@
+# Stock App Product Requirements
+
+## 1. Overview
+- **Goal**: Consolidate all of a user's investment portfolios across multiple brokers in a single application.
+- **Objectives**: Deliver accurate performance tracking (fees, dividends), automated dividend management, benchmarking, allocation analysis, return metrics (IRR/TTWRR/XIRR), and tax reporting.
+
+## 2. Functional Scope
+
+### 2.1 Portfolios and Accounts
+- Support multiple portfolios per user with nested broker and cash sub-accounts.
+- Allow quick switching between individual accounts and aggregated portfolio views.
+
+### 2.2 Holdings and Transactions
+- Persist buys, sells, fees, taxes, FX conversions, and corporate actions (splits, dividends, spin-offs).
+- Store transaction and portfolio base currencies, including FX rates.
+- Track cash events alongside asset trades.
+
+### 2.3 Dividend Automation and Analytics
+- Automatically ingest dividend payments and maintain a dividend calendar for upcoming distributions.
+- Calculate Dividend Yield, Yield on Cost, and track withholding tax per ISIN/broker.
+- Provide dividend ratings and "top dividend stocks" insights.
+
+### 2.4 Performance and Metrics
+- Compute IRR, XIRR, TTWRR, volatility, Sharpe ratio, beta, and P/E (when available).
+- Offer multi-period analytics (YTD, 1/3/5 year, custom), including cash performance.
+
+### 2.5 Benchmarking
+- Compare portfolio performance against indices or custom baskets with "what-if" simulations using identical cash flows.
+
+### 2.6 Allocation and Diversification
+- Break down allocation by asset class, region, sector, and currency using heatmaps and charts.
+
+### 2.7 Tax Reporting
+- Present realized gains/losses (short vs. long term), dividends by country of origin, and unrealized gains for tax-loss harvesting.
+- Export reports to CSV/PDF.
+
+### 2.8 Data Imports
+- Universal CSV import with configurable field mapping.
+- Provide default mapping profiles for Interactive Brokers, Revolut, Freetrade, TradeStation Global, and Degiro.
+- Allow manual transaction entry.
+
+### 2.9 Events and Notifications
+- Display upcoming corporate events (earnings, dividends, splits) via a customizable dashboard.
+- Support email and PWA push notifications for dividend reminders, earnings, and threshold alerts.
+
+## 3. Non-Functional Requirements
+- **Performance**: Filtering data for portfolios with 50k+ transactions must respond within 200 ms.
+- **Security**: Implement OAuth2 with WebAuthn, encrypt sensitive columns (AES-256-GCM), provide audit logging, RBAC (Owner, Member, Read-only), and IP allowlisting for admin.
+- **Privacy**: No account scraping without explicit consent; disclose FX rates and pricing data sources.
+- **Reliability**: Background jobs must be idempotent with exponential backoff retries and import checksums.
+
+## 4. Data Model (Minimum)
+- **User**: `id`, `email`, `auth_provider`, `2fa_enabled`, `created_at`
+- **Portfolio**: `id`, `user_id`, `name`, `base_currency`, `benchmark_id?`
+- **Account**: `id`, `portfolio_id`, `broker`, `account_name`, `type {broker|cash}`, `currency`
+- **Asset**: `id`, `symbol`, `isin?`, `name`, `type {stock|etf|bond|crypto|fund|cash}`, `sector?`, `region?`, `currency`
+- **Transaction**: `id`, `account_id`, `asset_id`, `type {BUY|SELL|DIVIDEND|FEE|TAX|SPLIT|FX}`, `qty`, `price`, `fee`, `tax`, `gross_amount`, `trade_currency`, `trade_time`, `fx_rate_to_portfolio_ccy`
+- **Dividend**: `id`, `account_id`, `asset_id`, `ex_date`, `pay_date`, `gross`, `withholding_tax`, `net`, `currency`
+- **Price**: `asset_id`, `date`, `close`, `currency`, `source`
+- **Benchmark**: `id`, `symbol|custom_series_ref`, `name`, `currency`
+- **ReportCache**: `portfolio_id`, `key`, `payload_json`, `computed_at`
+- **AuditLog**: `id`, `user_id`, `entity`, `entity_id`, `action`, `before`, `after`, `ts`
+
+> Transactions must model FX rates and fees at both transaction and account levels.
+
+## 5. CSV Import and Mapping
+- Universal CSV columns: `Account`, `Date`, `Type`, `Ticker/ISIN`, `Name`, `Qty`, `Price`, `Fee`, `Tax`, `Currency`, `GrossAmount`, `Notes`.
+- Drag-and-drop field mapper with preset profiles for common brokers.
+- Validation includes 100-row preview, checksum (`Σ qty*price + fees + taxes`), and duplicate detection using hash `{Account, Date, Ticker, Qty, Price}`.
+
+## 6. Analytics and Calculations
+- **Performance**: TTWRR, MWRR (IRR/XIRR), absolute and annualized net returns, multi-period insights with fees and dividends.
+- **Benchmarking**: Cash-flow normalized comparisons, "what-if" projections, tracking error, beta.
+- **Allocation**: Breakdown by class/region/sector/currency, top-N concentration, overweight warnings.
+- **Dividends**: Cashflow calendar, yield on cost, rolling 12-month income, stability/growth scoring.
+- **Risk**: Volatility, Sharpe ratio, max drawdown per portfolio and holding.
+- **Tax**: Realized P/L (short/long), dividends by country, unrealized P/L for harvesting, CSV/PDF export.
+
+## 7. User Interface
+- Customizable dashboard widgets (performance, dividend/earnings calendar, allocation heatmaps, cashflow).
+- Portfolio and account management with aggregation and filtering.
+- Holdings view with detailed metrics, history, dividends, and cost basis.
+- Transaction timeline with CRUD and bulk edits.
+- Dividend views (received, planned, calendar).
+- Reports for performance, taxes, and exports.
+- Import screens with broker profiles and validation.
+- Settings for currencies, benchmarks, roles, and integrations.
+
+## 8. Integrations and Data Providers
+- Modular market data providers for equities, ETFs, crypto; daily close fallback; FX rates from authoritative sources (e.g., ECB).
+- Notifications via email and PWA push.
+- REST/GraphQL APIs for CRUD and reporting with per-user API keys.
+
+## 9. Technology Recommendations
+- **Frontend**: React/Next.js with TypeScript, Zustand/Redux, React Query, PWA, Recharts for charts.
+- **Backend**: Node.js (NestJS) or Python (FastAPI) with BullMQ or Celery for job queues.
+- **Database**: PostgreSQL with partitioning (TimescaleDB for time series).
+- **Compute**: Stateless worker services, Redis caching.
+- **Infrastructure**: Docker, CI/CD, OpenAPI, and OpenTelemetry instrumentation.
+
+## 10. Acceptance Criteria (Selected)
+- CSV imports from supported brokers create transactions and compute TTWRR/IRR with <0.1% variance from checksum.
+- Dividend calendar updates net cashflow and Yield on Cost after withholding tax changes.
+- S&P 500 benchmark renders "what-if" curve with beta and tracking error.
+- Tax reports output short/long gains and dividend origins with CSV/PDF export.
+- Multi-currency dashboards respect portfolio base currency with dated FX transparency.
+- Dashboard widgets can be toggled and reordered by users.
+
+## 11. Test Data
+- Seed script populates 2 portfolios, 3 accounts, 20 tickers (stocks/ETF/crypto), 2 years of price history, 1,000 transactions, and 150 dividends.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+sqlalchemy==2.0.25
+pydantic==1.10.14
+python-multipart==0.0.9

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base, get_db
+from app.main import app
+
+SQLALCHEMY_DATABASE_URL = "sqlite://"
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture
+def db_session():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def client(db_session):
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+
+def test_portfolio_lifecycle(client):
+    # Create user
+    user_resp = client.post("/users/", json={"email": "user@example.com", "auth_provider": "password", "two_factor_enabled": False})
+    assert user_resp.status_code == 201
+    user_id = user_resp.json()["id"]
+
+    # Create benchmark
+    benchmark_resp = client.post("/benchmarks/", json={"symbol": "SP500", "name": "S&P 500", "currency": "USD"})
+    assert benchmark_resp.status_code == 201
+    benchmark_id = benchmark_resp.json()["id"]
+
+    # Create portfolio
+    portfolio_resp = client.post(
+        "/portfolios/",
+        json={"name": "Retirement", "base_currency": "USD", "user_id": user_id, "benchmark_id": benchmark_id},
+    )
+    assert portfolio_resp.status_code == 201
+    portfolio = portfolio_resp.json()
+
+    # Create account
+    account_resp = client.post(
+        "/accounts/",
+        json={
+            "portfolio_id": portfolio["id"],
+            "broker": "IBKR",
+            "account_name": "IBKR-1",
+            "type": "broker",
+            "currency": "USD",
+        },
+    )
+    assert account_resp.status_code == 201
+    account_id = account_resp.json()["id"]
+
+    # Create asset
+    asset_resp = client.post(
+        "/assets/",
+        json={
+            "symbol": "AAPL",
+            "isin": "US0378331005",
+            "name": "Apple Inc",
+            "type": "stock",
+            "sector": "Technology",
+            "region": "US",
+            "currency": "USD",
+        },
+    )
+    assert asset_resp.status_code == 201
+    asset_id = asset_resp.json()["id"]
+
+    # Record transactions
+    buy_resp = client.post(
+        "/transactions/",
+        json={
+            "account_id": account_id,
+            "asset_id": asset_id,
+            "type": "BUY",
+            "qty": "10",
+            "price": "150",
+            "fee": "1",
+            "tax": "0",
+            "gross_amount": "1500",
+            "trade_currency": "USD",
+            "fx_rate_to_portfolio_ccy": 1.0,
+            "trade_time": datetime.utcnow().isoformat(),
+        },
+    )
+    assert buy_resp.status_code == 201
+
+    sell_resp = client.post(
+        "/transactions/",
+        json={
+            "account_id": account_id,
+            "asset_id": asset_id,
+            "type": "SELL",
+            "qty": "5",
+            "price": "180",
+            "fee": "1",
+            "tax": "0",
+            "gross_amount": "900",
+            "trade_currency": "USD",
+            "fx_rate_to_portfolio_ccy": 1.0,
+            "trade_time": datetime.utcnow().isoformat(),
+        },
+    )
+    assert sell_resp.status_code == 201
+
+    # Record dividend
+    dividend_resp = client.post(
+        "/dividends/",
+        json={
+            "account_id": account_id,
+            "asset_id": asset_id,
+            "ex_date": "2023-01-01",
+            "pay_date": "2023-01-15",
+            "gross": "10",
+            "withholding_tax": "1",
+            "net": "9",
+            "currency": "USD",
+        },
+    )
+    assert dividend_resp.status_code == 201
+
+    # Add price
+    price_resp = client.post(
+        "/prices/",
+        json={
+            "asset_id": asset_id,
+            "date": "2023-12-31",
+            "close": "190",
+            "currency": "USD",
+            "source": "test",
+        },
+    )
+    assert price_resp.status_code == 201
+
+    # Portfolio performance
+    perf_resp = client.get(f"/portfolios/{portfolio['id']}/performance")
+    assert perf_resp.status_code == 200
+    performance = perf_resp.json()
+
+    assert performance["portfolio_id"] == portfolio["id"]
+    assert performance["dividends_received"] == 9.0
+    assert performance["current_value"] > 0


### PR DESCRIPTION
## Summary
- scaffold a FastAPI backend with SQLAlchemy models covering the core portfolio, account, asset, transaction, dividend, benchmark, and pricing entities
- expose CRUD and reporting endpoints including portfolio performance calculations and CSV import helpers
- add pytest fixtures and an end-to-end lifecycle test plus updated setup instructions and dependencies

## Testing
- pytest *(fails: missing fastapi dependency due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de3488e424832b8799654cb0ff35d6